### PR TITLE
fix critical bug with removeEntry

### DIFF
--- a/src/tests/jsonDatabase.ts
+++ b/src/tests/jsonDatabase.ts
@@ -123,8 +123,8 @@ export async function JsonDatabaseTests(_temp: PathLike) {
     );
     const types: DatabaseTypes[] = ["CHARACTER", "ANIME", "PERSON", "CATEGORY"];
     for (const type of types) {
-      for (let i = 0; i < 2; i++) {
-        await database.removeData(type, i);
+      for (let i = 1; i < 3; i++) {
+        assertSuccess(await database.removeData(type, i));
       }
     }
   } finally {

--- a/src/utilities/cached.ts
+++ b/src/utilities/cached.ts
@@ -101,16 +101,19 @@ export function removeEntryById<T extends KeyedEntry>(
   let { cache, entries } = table;
   let index = cache[id];
   if (index !== undefined) {
+    //nuke the cache
+    table.cache = {};
     //use the index to remove the stuffs
-    delete cache[id];
     entries.splice(index, 1);
     table.mutated = true;
     return true;
   }
   for (let i = 0; i < entries.length; i++) {
     if (entries[i].id === id) {
-      entries.splice(i, i);
+      entries.splice(i, 1);
       table.mutated = true;
+      //nuke the cache
+      table.cache = {};
       return true;
     }
   }


### PR DESCRIPTION
The removeEntry didnt nuke the cache, causing the wrong index to be returned after the function call